### PR TITLE
ci: add github pages publish

### DIFF
--- a/.github/workflows/bi_publish.yml
+++ b/.github/workflows/bi_publish.yml
@@ -1,0 +1,64 @@
+# Simple workflow for deploying static content to GitHub Pages
+name: Deploy static content to Pages
+
+on:
+  # Runs on pushes targeting the default branch
+  push:
+    # TODO: Revert to main before merging
+    # branches: ["main"]
+    branches: ["feat-github-pages"]
+
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+
+# Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+# Allow one concurrent deployment
+concurrency:
+  group: "pages"
+  cancel-in-progress: true
+
+jobs:
+  build:
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+        with:
+          python-version: "3.10"
+      - name: Install Meltano
+        run: pipx install meltano
+      - name: Install dbt and other tools
+        run: meltano install
+      - name: Extract, Load, and Transform
+        run: meltano run elt
+      - name: Build Reports
+        # TODO: use `build-strict` once available
+        run: meltano invoke evidence:build
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v1
+        with:
+          path: 'reports/build'
+      - name: Upload artifact
+        uses: actions/upload-artifact@v1
+        with:
+          path: 'reports/jaffle_shop.dev-duckdb'
+
+  deploy:
+    needs: build
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: Setup Pages
+        uses: actions/configure-pages@v3
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v1

--- a/.github/workflows/bi_publish.yml
+++ b/.github/workflows/bi_publish.yml
@@ -1,5 +1,5 @@
 # Simple workflow for deploying static content to GitHub Pages
-name: Deploy static content to Pages
+name: Deploy BI to GitHub Pages
 
 on:
   # Runs on pushes targeting the default branch
@@ -43,10 +43,11 @@ jobs:
         uses: actions/upload-pages-artifact@v1
         with:
           path: 'reports/build'
-      - name: Upload artifact
-        uses: actions/upload-artifact@v1
-        with:
-          path: 'reports/jaffle_shop.dev-duckdb'
+      # - name: Upload artifact
+      #   uses: actions/upload-artifact@v1
+      #   with:
+      #     path: 'reports/jaffle_shop.dev-duckdb'
+      #     name: ci-build.duckdb
 
   deploy:
     needs: build

--- a/.github/workflows/bi_publish.yml
+++ b/.github/workflows/bi_publish.yml
@@ -4,9 +4,7 @@ name: Deploy BI to GitHub Pages
 on:
   # Runs on pushes targeting the default branch
   push:
-    # TODO: Revert to main before merging
-    # branches: ["main"]
-    branches: ["feat-github-pages"]
+    branches: ["main"]
 
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
@@ -43,11 +41,6 @@ jobs:
         uses: actions/upload-pages-artifact@v1
         with:
           path: 'reports/build'
-      # - name: Upload artifact
-      #   uses: actions/upload-artifact@v1
-      #   with:
-      #     path: 'reports/jaffle_shop.dev-duckdb'
-      #     name: ci-build.duckdb
 
   deploy:
     needs: build


### PR DESCRIPTION
It's working! 🚀 

https://meltanolabs.github.io/jaffle-shop-template/

Update: There were some post-merge updates to resolve additional issues:

- Hotfix on reports for relative report paths from non-root host url: https://github.com/MeltanoLabs/jaffle-shop-template/commit/a1d0ffef8bf7027fed208c4fce2f5f28d3ce482d
- My latest version of the GitHub Pages deploy workflow: https://github.com/MeltanoLabs/jaffle-shop-template/blob/main/.github/workflows/bi_publish.yml
- Remaining issue with hosting from non-root URL: https://github.com/MeltanoLabs/jaffle-shop-template/issues/6




