### PR TITLE
Chore: move project-id to client-id

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -37,6 +37,9 @@
 		"cschleiden.vscode-github-actions"
 	]
     }
+  },
+  "containerEnv": {
+	"MELTANO_CLIENT_ID": "bd6709c7-2d8b-4aba-9697-f6cd61582e74" // Unique ID for Jaffle Shop Template
   }
 }
 // For format details, see https://aka.ms/devcontainer.json. For config options, see the

--- a/meltano.yml
+++ b/meltano.yml
@@ -11,7 +11,6 @@
 # Repeat the same actions as above on "prod":
 # > meltano --environment=prod run elt evidence:build
 
-project_id: bd6709c7-2d8b-4aba-9697-f6cd61582e74
 version: 1
 
 jobs:

--- a/meltano.yml
+++ b/meltano.yml
@@ -46,20 +46,20 @@ environments:
   env:
     JAFFLE_DB_PATH: ${MELTANO_PROJECT_ROOT}/reports/jaffle_shop.${MELTANO_ENVIRONMENT}-duckdb
     JAFFLE_DB_NAME: jaffle_shop
-    JAFFLE_RAW_SCHEMA: "tap_jaffle_shop"
-    TAP_JAFFLE_SHOP_YEARS: "1"
+    JAFFLE_RAW_SCHEMA: tap_jaffle_shop
+    TAP_JAFFLE_SHOP_YEARS: '1'
 - name: staging
   env:
     JAFFLE_DB_PATH: ${MELTANO_PROJECT_ROOT}/reports/jaffle_shop.${MELTANO_ENVIRONMENT}-duckdb
     JAFFLE_DB_NAME: jaffle_shop
-    JAFFLE_RAW_SCHEMA: "tap_jaffle_shop"
-    TAP_JAFFLE_SHOP_YEARS: "3"
+    JAFFLE_RAW_SCHEMA: tap_jaffle_shop
+    TAP_JAFFLE_SHOP_YEARS: '3'
 - name: prod
   env:
     JAFFLE_DB_PATH: ${MELTANO_PROJECT_ROOT}/reports/jaffle_shop.${MELTANO_ENVIRONMENT}-duckdb
     JAFFLE_DB_NAME: jaffle_shop
-    JAFFLE_RAW_SCHEMA: "tap_jaffle_shop"
-    TAP_JAFFLE_SHOP_YEARS: "5"
+    JAFFLE_RAW_SCHEMA: tap_jaffle_shop
+    TAP_JAFFLE_SHOP_YEARS: '5'
 
 plugins:
   extractors:
@@ -93,11 +93,12 @@ plugins:
   - name: evidence
     variant: meltanolabs
     pip_url: evidence-ext>=0.5
+    commands:
+      dev: dev
     config:
       home_dir: ${MELTANO_PROJECT_ROOT}/reports
       settings:
         duckdb:
           # filename: ${MELTANO_PROJECT_ROOT}/reports/${JAFFLE_DB_NAME}.${MELTANO_ENVIRONMENT}.duckdb
           filename: ${JAFFLE_DB_NAME}.${MELTANO_ENVIRONMENT}-duckdb
-    commands:
-      dev: dev
+project_id: ff061732-bd27-4021-916f-e8f8b55fcf9d


### PR DESCRIPTION
Some caveats I need to call out with this PR...

First, I noted that the client ID is correctly carried through into the `analytics.json` file, via the env var in the Codespace.

```
@aaronsteers ➜ /workspaces/jaffle-shop-template (chore-move-project-id-to-client-id) $ echo $MELTANO_CLIENT_ID
bd6709c7-2d8b-4aba-9697-f6cd61582e74
@aaronsteers ➜ /workspaces/jaffle-shop-template (chore-move-project-id-to-client-id) $ cat .meltano/analytics.json
{"client_id": "bd6709c7-2d8b-4aba-9697-f6cd61582e74", "project_id": "ff061732-bd27-4021-916f-e8f8b55fcf9d", "send_anonymous_usage_stats": true}%                                                                                                                          
@aaronsteers ➜ /workspaces/jaffle-shop-template (chore-move-project-id-to-client-id) 
```

Second, the process of running `meltano install` now immediately creates a git diff, as `meltano.yml` is immediately updated with the `project_id`. Since `meltano install` is set to run in `postCreate` on the container, starting with #8, this means the user immediately starts out the repo with a pending diff in git. That might not be a huge deal for a Meltano tutorial, but as we may want to include Meltano in projects that are not intended _only_ for working on Meltano - or which are focused on the `live demo` experience more than the tutorial experience. For a live demo, we really don't want to start out with an immediate diff at the very outset of launching the project.

Third, the CLI changing the file creates some undesireable diffs for formatting and sorting of keys. I'll open a bug in `meltano/meltano` to see if we can reduce these. The best mitigation is for maintainers to periodically commit back the auto-applied changes so that future users don't see these pending diffs when they are running the tutorials or exercises.

Here's the commit containing all aspects of the file that were changed:

https://github.com/meltano/jaffle-shop-template/pull/9/commits/decbe25bc2334b1c6af974f0bedbd70c3c973aa5