### PR TITLE
Feat: add exchangerates data

### DIFF
--- a/meltano.yml
+++ b/meltano.yml
@@ -73,6 +73,12 @@ plugins:
     config:
       years: 1
       stream_name_prefix: ${JAFFLE_RAW_SCHEMA}-raw_
+  - name: tap-exchangeratehost
+    variant: anelendata
+    pip_url: git+https://github.com/anelendata/tap-exchangeratehost.git
+    config:
+      start_date: '2020-01-01'
+      base: USD
   loaders:
   - name: target-duckdb
     variant: jwills

--- a/plugins/extractors/tap-exchangeratehost--anelendata.lock
+++ b/plugins/extractors/tap-exchangeratehost--anelendata.lock
@@ -1,0 +1,34 @@
+{
+  "plugin_type": "extractors",
+  "name": "tap-exchangeratehost",
+  "namespace": "tap_exchangeratehost",
+  "variant": "anelendata",
+  "label": "exchangerate.host",
+  "docs": "https://hub.meltano.com/extractors/tap-exchangeratehost--anelendata",
+  "repo": "https://github.com/anelendata/tap-exchangeratehost",
+  "pip_url": "git+https://github.com/anelendata/tap-exchangeratehost.git",
+  "description": "Exchange Rate API",
+  "logo_url": "https://hub.meltano.com/assets/logos/extractors/exchangeratehost.png",
+  "capabilities": [
+    "state"
+  ],
+  "settings": [
+    {
+      "name": "start_date",
+      "kind": "date_iso8601",
+      "label": "Start Date",
+      "description": "Determines how much historical data will be extracted. Please be aware that the larger the time period and amount of data, the longer the initial extraction can be expected to take."
+    },
+    {
+      "name": "end_date",
+      "kind": "date_iso8601",
+      "label": "End Date",
+      "description": "The end date for when the sync should stop pulling data."
+    },
+    {
+      "name": "base",
+      "label": "Base",
+      "description": "Changing base currency. Enter the three-letter currency code of your preferred base currency. For example - base=USD. (Default EUR)"
+    }
+  ]
+}


### PR DESCRIPTION
No API key needed. And rate limits were not a problem going back to Jan 1 2020. 

And entire EL run takes <20 second, including load time to target-duckdb:

```
meltano run tap-exchangeratehost target-duckdb
```

Or to force a full refresh:

```
meltano run tap-exchangeratehost target-duckdb --full-refresh
```

As of now, I don't have any transformations to make use of this data, but I thought I'd neverthess kick off this PR as a conversation starter for this or other sources.